### PR TITLE
Multiple code improvements - squid:S1301, squid:S1213, squid:SwitchLastCaseIsDefaultCheck, squid:S2131, squid:S1118

### DIFF
--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/AnimationUseActivity.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/AnimationUseActivity.java
@@ -36,7 +36,7 @@ public class AnimationUseActivity extends Activity {
         mQuickAdapter.setOnRecyclerViewItemClickListener(new BaseQuickAdapter.OnRecyclerViewItemClickListener() {
             @Override
             public void onItemClick(View view, int position) {
-                Toast.makeText(AnimationUseActivity.this, "" + position, Toast.LENGTH_LONG).show();
+                Toast.makeText(AnimationUseActivity.this, Integer.toString(position), Toast.LENGTH_LONG).show();
             }
         });
         mRecyclerView.setAdapter(mQuickAdapter);
@@ -68,7 +68,8 @@ public class AnimationUseActivity extends Activity {
                     case 5:
                         mQuickAdapter.openLoadAnimation(new CustomAnimation());
                         break;
-
+                    default:
+                        break;
                 }
                 mRecyclerView.setAdapter(mQuickAdapter);
             }
@@ -85,6 +86,8 @@ public class AnimationUseActivity extends Activity {
                         break;
                     case 1:
                         mQuickAdapter.isFirstOnly(false);
+                        break;
+                    default:
                         break;
                 }
                 mQuickAdapter.notifyDataSetChanged();

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/HeaderAndFooterUseActivity.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/HeaderAndFooterUseActivity.java
@@ -52,7 +52,7 @@ public class HeaderAndFooterUseActivity extends Activity {
         mQuickAdapter.setOnRecyclerViewItemClickListener(new BaseQuickAdapter.OnRecyclerViewItemClickListener() {
             @Override
             public void onItemClick(View view, int position) {
-                Toast.makeText(HeaderAndFooterUseActivity.this, "" + position, Toast.LENGTH_LONG).show();
+                Toast.makeText(HeaderAndFooterUseActivity.this, "" + Integer.toString(position), Toast.LENGTH_LONG).show();
             }
         });
     }

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/PullToRefreshUseActivity.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/PullToRefreshUseActivity.java
@@ -28,6 +28,8 @@ public class PullToRefreshUseActivity extends Activity implements BaseQuickAdapt
 
     private static final int PAGE_SIZE = 6;
 
+    private int delayMillis = 1000;
+
     private int mCurrentCounter = 0;
 
     @Override
@@ -54,7 +56,7 @@ public class PullToRefreshUseActivity extends Activity implements BaseQuickAdapt
         });
         mQuickAdapter.addHeaderView(headView);
     }
-    private int delayMillis = 1000;
+
     @Override
     public void onLoadMoreRequested() {
         if (mCurrentCounter >= TOTAL_COUNTER) {
@@ -100,7 +102,7 @@ public class PullToRefreshUseActivity extends Activity implements BaseQuickAdapt
         mQuickAdapter.setOnRecyclerViewItemClickListener(new BaseQuickAdapter.OnRecyclerViewItemClickListener() {
             @Override
             public void onItemClick(View view, int position) {
-                Toast.makeText(PullToRefreshUseActivity.this, "" + position, Toast.LENGTH_LONG).show();
+                Toast.makeText(PullToRefreshUseActivity.this, Integer.toString(position), Toast.LENGTH_LONG).show();
             }
         });
     }

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/data/DataServer.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/data/DataServer.java
@@ -12,6 +12,9 @@ import java.util.List;
  * https://github.com/CymChad/BaseRecyclerViewAdapterHelper
  */
 public class DataServer {
+
+    private DataServer() {}
+
     public static List<Status> getSampleData(int lenth) {
         List<Status> list = new ArrayList<>();
         for (int i = 0; i < lenth; i++) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1301 - "switch" statements should have at least 3 "case" clauses.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
squid:S2131 - Primitives should not be boxed just for "String" conversion.
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1301
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/rules/show/squid:S2131
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava