### PR TITLE
squid:S1192 - String literals should not be duplicated

### DIFF
--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/data/DataServer.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/data/DataServer.java
@@ -13,6 +13,9 @@ import java.util.List;
  */
 public class DataServer {
 
+    private static final String HTTPS_AVATARS1_GITHUBUSERCONTENT_COM_LINK = "https://avatars1.githubusercontent.com/u/7698209?v=3&s=460";
+    private static final String CYM_CHAD = "CymChad";
+
     private DataServer() {}
 
     public static List<Status> getSampleData(int lenth) {
@@ -46,32 +49,32 @@ public class DataServer {
     public static List<MySection> getSampleData() {
         List<MySection> list = new ArrayList<>();
         list.add(new MySection(true, "2016/4/8", true));
-        list.add(new MySection(new Video("https://avatars1.githubusercontent.com/u/7698209?v=3&s=460", "CymChad")));
-        list.add(new MySection(new Video("https://avatars1.githubusercontent.com/u/7698209?v=3&s=460", "CymChad")));
-        list.add(new MySection(new Video("https://avatars1.githubusercontent.com/u/7698209?v=3&s=460", "CymChad")));
-        list.add(new MySection(new Video("https://avatars1.githubusercontent.com/u/7698209?v=3&s=460", "CymChad")));
+        list.add(new MySection(new Video(HTTPS_AVATARS1_GITHUBUSERCONTENT_COM_LINK, CYM_CHAD)));
+        list.add(new MySection(new Video(HTTPS_AVATARS1_GITHUBUSERCONTENT_COM_LINK, CYM_CHAD)));
+        list.add(new MySection(new Video(HTTPS_AVATARS1_GITHUBUSERCONTENT_COM_LINK, CYM_CHAD)));
+        list.add(new MySection(new Video(HTTPS_AVATARS1_GITHUBUSERCONTENT_COM_LINK, CYM_CHAD)));
         list.add(new MySection(true, "2016/4/7", false));
-        list.add(new MySection(new Video("https://avatars1.githubusercontent.com/u/7698209?v=3&s=460", "CymChad")));
-        list.add(new MySection(new Video("https://avatars1.githubusercontent.com/u/7698209?v=3&s=460", "CymChad")));
-        list.add(new MySection(new Video("https://avatars1.githubusercontent.com/u/7698209?v=3&s=460", "CymChad")));
+        list.add(new MySection(new Video(HTTPS_AVATARS1_GITHUBUSERCONTENT_COM_LINK, CYM_CHAD)));
+        list.add(new MySection(new Video(HTTPS_AVATARS1_GITHUBUSERCONTENT_COM_LINK, CYM_CHAD)));
+        list.add(new MySection(new Video(HTTPS_AVATARS1_GITHUBUSERCONTENT_COM_LINK, CYM_CHAD)));
         list.add(new MySection(true, "2016/4/6", false));
-        list.add(new MySection(new Video("https://avatars1.githubusercontent.com/u/7698209?v=3&s=460", "CymChad")));
-        list.add(new MySection(new Video("https://avatars1.githubusercontent.com/u/7698209?v=3&s=460", "CymChad")));
+        list.add(new MySection(new Video(HTTPS_AVATARS1_GITHUBUSERCONTENT_COM_LINK, CYM_CHAD)));
+        list.add(new MySection(new Video(HTTPS_AVATARS1_GITHUBUSERCONTENT_COM_LINK, CYM_CHAD)));
         list.add(new MySection(true, "2016/4/5", false));
-        list.add(new MySection(new Video("https://avatars1.githubusercontent.com/u/7698209?v=3&s=460", "CymChad")));
-        list.add(new MySection(new Video("https://avatars1.githubusercontent.com/u/7698209?v=3&s=460", "CymChad")));
+        list.add(new MySection(new Video(HTTPS_AVATARS1_GITHUBUSERCONTENT_COM_LINK, CYM_CHAD)));
+        list.add(new MySection(new Video(HTTPS_AVATARS1_GITHUBUSERCONTENT_COM_LINK, CYM_CHAD)));
         list.add(new MySection(true, "2016/4/4", false));
-        list.add(new MySection(new Video("https://avatars1.githubusercontent.com/u/7698209?v=3&s=460", "CymChad")));
-        list.add(new MySection(new Video("https://avatars1.githubusercontent.com/u/7698209?v=3&s=460", "CymChad")));
+        list.add(new MySection(new Video(HTTPS_AVATARS1_GITHUBUSERCONTENT_COM_LINK, CYM_CHAD)));
+        list.add(new MySection(new Video(HTTPS_AVATARS1_GITHUBUSERCONTENT_COM_LINK, CYM_CHAD)));
         return list;
     }
 
     public static List<String> getStrData() {
         List<String> list = new ArrayList<>();
         for (int i = 0; i < 20; i++) {
-            String str = "https://avatars1.githubusercontent.com/u/7698209?v=3&s=460";
+            String str = HTTPS_AVATARS1_GITHUBUSERCONTENT_COM_LINK;
             if (i % 2 == 0) {
-                str = "CymChad";
+                str = CYM_CHAD;
             }
             list.add(str);
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
`squid:S1192` - String literals should not be duplicated.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
Please let me know if you have any questions.
George Kankava