### PR TITLE
just do a little change about 'Context'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,10 @@ proguard/
 .gradle
 .idea
 build
+.DS_Store
+local.properties
+# build files
+output/
+# android studio
+*.iml
+.idea

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,9 +3,8 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="distributionType" value="LOCAL" />
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleHome" value="$APPLICATION_HOME_DIR$/gradle/gradle-2.8" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,10 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="EntryPointsManager">
+    <entry_points version="2.0" />
+  </component>
   <component name="MavenImportPreferences">
     <option name="generalSettings">
       <MavenGeneralSettings>
         <option name="mavenHome" value="Bundled (Maven 3)" />
       </MavenGeneralSettings>
+    </option>
+  </component>
+  <component name="NullableNotNullManager">
+    <option name="myDefaultNullable" value="android.support.annotation.Nullable" />
+    <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
+    <option name="myNullables">
+      <value>
+        <list size="4">
+          <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
+          <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
+          <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
+          <item index="3" class="java.lang.String" itemvalue="android.support.annotation.Nullable" />
+        </list>
+      </value>
+    </option>
+    <option name="myNotNulls">
+      <value>
+        <list size="4">
+          <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
+          <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
+          <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
+          <item index="3" class="java.lang.String" itemvalue="android.support.annotation.NonNull" />
+        </list>
+      </value>
     </option>
   </component>
   <component name="ProjectInspectionProfilesVisibleTreeState">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="EntryPointsManager">
-    <entry_points version="2.0" />
-  </component>
   <component name="MavenImportPreferences">
     <option name="generalSettings">
       <MavenGeneralSettings>
-        <option name="mavenHome" value="$USER_HOME$/zaizaisofte/maven" />
-        <option name="userSettingsFile" value="$USER_HOME$/MavenRepository/settings.xml" />
+        <option name="mavenHome" value="Bundled (Maven 3)" />
       </MavenGeneralSettings>
     </option>
   </component>
-  <component name="NullableNotNullManager">
-    <option name="myDefaultNullable" value="android.support.annotation.Nullable" />
-    <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
-    <option name="myNullables">
-      <value>
-        <list size="4">
-          <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
-          <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
-          <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
-          <item index="3" class="java.lang.String" itemvalue="android.support.annotation.Nullable" />
-        </list>
-      </value>
-    </option>
-    <option name="myNotNulls">
-      <value>
-        <list size="4">
-          <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
-          <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
-          <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
-          <item index="3" class="java.lang.String" itemvalue="android.support.annotation.NonNull" />
-        </list>
-      </value>
-    </option>
+  <component name="ProjectInspectionProfilesVisibleTreeState">
+    <entry key="Project Default">
+      <profile-state>
+        <expanded-state>
+          <State>
+            <id />
+          </State>
+          <State>
+            <id>Android</id>
+          </State>
+          <State>
+            <id>Android Lint</id>
+          </State>
+          <State>
+            <id>Java</id>
+          </State>
+          <State>
+            <id>Java language level migration aidsJava</id>
+          </State>
+        </expanded-state>
+        <selected-state>
+          <State>
+            <id>Android</id>
+          </State>
+        </selected-state>
+      </profile-state>
+    </entry>
   </component>
   <component name="ProjectLevelVcsManager" settingsEditedManually="false">
     <OptionsSetting value="true" id="Add" />
@@ -50,32 +50,5 @@
   </component>
   <component name="ProjectType">
     <option name="id" value="Android" />
-  </component>
-  <component name="masterDetails">
-    <states>
-      <state key="ProjectJDKs.UI">
-        <settings>
-          <last-edited>1.8</last-edited>
-          <splitter-proportions>
-            <option name="proportions">
-              <list>
-                <option value="0.2" />
-              </list>
-            </option>
-          </splitter-proportions>
-        </settings>
-      </state>
-      <state key="ScopeChooserConfigurable.UI">
-        <settings>
-          <splitter-proportions>
-            <option name="proportions">
-              <list>
-                <option value="0.2" />
-              </list>
-            </option>
-          </splitter-proportions>
-        </settings>
-      </state>
-    </states>
   </component>
 </project>

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,13 @@
-/build
+.gradle/
+.DS_Store
+local.properties
+
+# build files
+build/
+bin/
+gen/
+output/
+
+# android studio
+*.iml
+.idea

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/AnimationUseActivity.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/AnimationUseActivity.java
@@ -32,7 +32,7 @@ public class AnimationUseActivity extends Activity {
     }
 
     private void initAdapter() {
-        mQuickAdapter = new QuickAdapter(this);
+        mQuickAdapter = new QuickAdapter();
         mQuickAdapter.openLoadAnimation();
         mQuickAdapter.setOnRecyclerViewItemChildClickListener(new BaseQuickAdapter.OnRecyclerViewItemChildClickListener() {
             @Override

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/HomeActivity.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/HomeActivity.java
@@ -31,7 +31,7 @@ public class HomeActivity extends Activity {
         mRecyclerView = (RecyclerView) findViewById(R.id.rv_list);
         mRecyclerView.setLayoutManager(new LinearLayoutManager(this));
         initData();
-        BaseQuickAdapter homeAdapter = new HomeAdapter(this, R.layout.home_item_view, mDataList);
+        BaseQuickAdapter homeAdapter = new HomeAdapter( R.layout.home_item_view, mDataList);
         homeAdapter.openLoadAnimation();
         homeAdapter.setOnRecyclerViewItemClickListener(new BaseQuickAdapter.OnRecyclerViewItemClickListener() {
             @Override

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/SectionUseActivity.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/SectionUseActivity.java
@@ -28,7 +28,7 @@ public class SectionUseActivity extends Activity implements BaseQuickAdapter.OnR
         mRecyclerView = (RecyclerView) findViewById(R.id.rv_list);
         mRecyclerView.setLayoutManager(new StaggeredGridLayoutManager(2, StaggeredGridLayoutManager.VERTICAL));
         mData = DataServer.getSampleData();
-        SectionAdapter sectionAdapter = new SectionAdapter(this, R.layout.item_section_content, R.layout.def_section_head, mData);
+        SectionAdapter sectionAdapter = new SectionAdapter(R.layout.item_section_content, R.layout.def_section_head, mData);
         sectionAdapter.setOnRecyclerViewItemClickListener(this);
         sectionAdapter.setOnRecyclerViewItemChildClickListener(new BaseQuickAdapter.OnRecyclerViewItemChildClickListener() {
             @Override

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/HomeAdapter.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/HomeAdapter.java
@@ -1,7 +1,6 @@
 package com.chad.baserecyclerviewadapterhelper.adapter;
 
 import android.animation.Animator;
-import android.content.Context;
 import android.graphics.Color;
 import android.support.v7.widget.CardView;
 
@@ -16,8 +15,8 @@ import java.util.List;
  * https://github.com/CymChad/BaseRecyclerViewAdapterHelper
  */
 public class HomeAdapter extends BaseQuickAdapter<HomeItem> {
-    public HomeAdapter(Context context, int layoutResId, List data) {
-        super(context, layoutResId, data);
+    public HomeAdapter(int layoutResId, List data) {
+        super(layoutResId, data);
     }
 
     @Override

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/MultipleItemAdapter.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/MultipleItemAdapter.java
@@ -1,6 +1,5 @@
 package com.chad.baserecyclerviewadapterhelper.adapter;
 
-import android.content.Context;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
@@ -21,8 +20,8 @@ public class MultipleItemAdapter extends BaseQuickAdapter<String> {
     private int mTextLayoutResId;
 
 
-    public MultipleItemAdapter(Context context, List data, int... layoutResId) {
-        super(context, layoutResId[0], data);
+    public MultipleItemAdapter( List data, int... layoutResId) {
+        super( layoutResId[0], data);
         mTextLayoutResId = layoutResId[1];
     }
 

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/MultipleItemQuickAdapter.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/MultipleItemQuickAdapter.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class MultipleItemQuickAdapter extends BaseMultiItemQuickAdapter<MultipleItem> {
 
     public MultipleItemQuickAdapter(Context context, List data) {
-        super(context, data);
+        super( data);
         addItemType(MultipleItem.TEXT, R.layout.item_text_view);
         addItemType(MultipleItem.IMG, R.layout.item_image_view);
         addItemType(MultipleItem.IMGS, R.layout.item_image_views);

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/QuickAdapter.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/QuickAdapter.java
@@ -15,12 +15,12 @@ import com.chad.library.adapter.base.BaseViewHolder;
  * https://github.com/CymChad/BaseRecyclerViewAdapterHelper
  */
 public class QuickAdapter extends BaseQuickAdapter<Status> {
-    public QuickAdapter(Context context) {
-        super(context, R.layout.tweet, DataServer.getSampleData(100));
+    public QuickAdapter() {
+        super( R.layout.tweet, DataServer.getSampleData(100));
     }
 
     public QuickAdapter(Context context, int dataSize) {
-        super(context, R.layout.tweet, DataServer.getSampleData(dataSize));
+        super( R.layout.tweet, DataServer.getSampleData(dataSize));
     }
 
     @Override

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/SectionAdapter.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/adapter/SectionAdapter.java
@@ -1,7 +1,5 @@
 package com.chad.baserecyclerviewadapterhelper.adapter;
 
-import android.content.Context;
-
 import com.chad.baserecyclerviewadapterhelper.R;
 import com.chad.baserecyclerviewadapterhelper.entity.MySection;
 import com.chad.baserecyclerviewadapterhelper.entity.Video;
@@ -18,13 +16,12 @@ public class SectionAdapter extends BaseSectionQuickAdapter<MySection> {
      * Same as QuickAdapter#QuickAdapter(Context,int) but with
      * some initialization data.
      *
-     * @param context     The context.
      * @param sectionHeadResId The section head layout id for each item
      * @param layoutResId The layout resource id of each item.
      * @param data        A new list is created out of this one to avoid mutable list
      */
-    public SectionAdapter(Context context, int layoutResId, int sectionHeadResId, List data) {
-        super(context, layoutResId, sectionHeadResId, data);
+    public SectionAdapter( int layoutResId, int sectionHeadResId, List data) {
+        super( layoutResId, sectionHeadResId, data);
     }
 
     @Override

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 21 11:34:03 PDT 2015
+#Fri Jun 17 11:45:15 CST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/library/.gitignore
+++ b/library/.gitignore
@@ -1,1 +1,13 @@
-/build
+.gradle/
+.DS_Store
+local.properties
+
+# build files
+build/
+bin/
+gen/
+output/
+
+# android studio
+*.iml
+.idea

--- a/library/src/main/java/com/chad/library/adapter/base/BaseMultiItemQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseMultiItemQuickAdapter.java
@@ -1,6 +1,5 @@
 package com.chad.library.adapter.base;
 
-import android.content.Context;
 import android.util.SparseArray;
 import android.view.ViewGroup;
 
@@ -22,11 +21,10 @@ public abstract class BaseMultiItemQuickAdapter<T extends MultiItemEntity> exten
      * Same as QuickAdapter#QuickAdapter(Context,int) but with
      * some initialization data.
      *
-     * @param context The context.
      * @param data    A new list is created out of this one to avoid mutable list
      */
-    public BaseMultiItemQuickAdapter(Context context, List<T> data) {
-        super(context, data);
+    public BaseMultiItemQuickAdapter( List<T> data) {
+        super( data);
     }
 
     @Override

--- a/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
@@ -198,31 +198,25 @@ public abstract class BaseQuickAdapter<T> extends RecyclerView.Adapter<RecyclerV
      * Same as QuickAdapter#QuickAdapter(Context,int) but with
      * some initialization data.
      *
-     * @param context     The context.
      * @param layoutResId The layout resource id of each item.
      * @param data        A new list is created out of this one to avoid mutable list
      */
-    public BaseQuickAdapter(Context context, int layoutResId, List<T> data) {
+    public BaseQuickAdapter( int layoutResId, List<T> data) {
         this.mData = data == null ? new ArrayList<T>() : data;
-        this.mContext = context;
-        this.mLayoutInflater = LayoutInflater.from(context);
         if (layoutResId != 0) {
             this.mLayoutResId = layoutResId;
         }
     }
 
-    public BaseQuickAdapter(Context context, List<T> data) {
-        this(context, 0, data);
+    public BaseQuickAdapter( List<T> data) {
+        this(0, data);
     }
 
-    public BaseQuickAdapter(Context context, View contentView, List<T> data) {
-        this(context, 0, data);
+    public BaseQuickAdapter(View contentView, List<T> data) {
+        this( 0, data);
         mContentView = contentView;
     }
 
-    public BaseQuickAdapter(Context context) {
-        this(context, null);
-    }
 
     public void remove(int position) {
         mData.remove(position);
@@ -383,6 +377,8 @@ public abstract class BaseQuickAdapter<T> extends RecyclerView.Adapter<RecyclerV
     @Override
     public BaseViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         BaseViewHolder baseViewHolder = null;
+        this.mContext = parent.getContext();
+        this.mLayoutInflater = LayoutInflater.from(mContext);
         switch (viewType) {
             case LOADING_VIEW:
                 baseViewHolder = getLoadingView(parent);

--- a/library/src/main/java/com/chad/library/adapter/base/BaseSectionQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseSectionQuickAdapter.java
@@ -1,6 +1,5 @@
 package com.chad.library.adapter.base;
 
-import android.content.Context;
 import android.view.ViewGroup;
 
 import com.chad.library.adapter.base.entity.SectionEntity;
@@ -20,13 +19,12 @@ public abstract class BaseSectionQuickAdapter<T extends SectionEntity> extends B
      * Same as QuickAdapter#QuickAdapter(Context,int) but with
      * some initialization data.
      *
-     * @param context          The context.
      * @param sectionHeadResId The section head layout id for each item
      * @param layoutResId      The layout resource id of each item.
      * @param data             A new list is created out of this one to avoid mutable list
      */
-    public BaseSectionQuickAdapter(Context context, int layoutResId, int sectionHeadResId, List<T> data) {
-        super(context, layoutResId, data);
+    public BaseSectionQuickAdapter( int layoutResId, int sectionHeadResId, List<T> data) {
+        super(layoutResId, data);
         this.mSectionHeadResId = sectionHeadResId;
     }
 


### PR DESCRIPTION
before 
We pass context into BaseQuickAdapter or BaseMultiItemQuickAdapter,that looks like a waste.

explain
because about RecyclerView.Adapter.onCreateViewHolder.So we can do below method that replace external transmit 'Context'.

see code method
    RecyclerView.Adapter.onCreateViewHolder(ViewGroup parent, int viewType) {
    {
		this.mContext = parent.getContext();
		...
    }