### PR TITLE
Update BaseQuickAdapter.java

### DIFF
--- a/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
@@ -233,6 +233,16 @@ public abstract class BaseQuickAdapter<T> extends RecyclerView.Adapter<RecyclerV
         }
         notifyDataSetChanged();
     }
+    
+    /**
+     *  same as addData(List<T>) but for when data is manually added to the adapter
+     */
+    public void dataAdded() {
+        if (mNextLoadEnable) {
+            mLoadingMoreEnable = false;
+        }
+        notifyDataSetChanged();
+    }
 
     /**
      * set a loadingView


### PR DESCRIPTION
When manually manipulating the adapter list (e.g. when using `adapter.getData().add(...)` and `adapter.notifyDataSetChanged()` instead of using `adapter.addData(..)`) there was no way to trigger a completed load of data. Meaning that the 'load more' at the bottom of the list would stay visible even though more items had been successfully loaded. Now this can be done with `adapter.dataAdded()`.

Behavior is similar to `adapter.loadComplete()`, however `adapter.loadComplete()` indicates that there is nothing to load more (i.e. the complete list is loaded). `adapter.dataAdded()` simply indicates that 1 single load has been completed, but that there might still be more data to load.