### PR TITLE
fix #601 #607

### DIFF
--- a/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
@@ -75,7 +75,7 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
     private LinearLayout mHeaderLayout;
     private LinearLayout mFooterLayout;
     //empty
-    private FrameLayout mEmptyView;
+    private FrameLayout mEmptyLayout;
     private boolean mIsUseEmpty = true;
     private boolean mHeadAndEmptyEnable;
     private boolean mFootAndEmptyEnable;
@@ -414,12 +414,12 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
     }
 
     /**
-     * if mEmptyView will be return 1 or not will be return 0
+     * if show empty view will be return 1 or not will be return 0
      *
      * @return
      */
     public int getEmptyViewCount() {
-        if (mEmptyView == null || mEmptyView.getChildCount() == 0) {
+        if (mEmptyLayout == null || mEmptyLayout.getChildCount() == 0) {
             return 0;
         }
         if(!mIsUseEmpty){
@@ -507,7 +507,7 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
                 baseViewHolder = createBaseViewHolder(mHeaderLayout);
                 break;
             case EMPTY_VIEW:
-                baseViewHolder = createBaseViewHolder(mEmptyView);
+                baseViewHolder = createBaseViewHolder(mEmptyLayout);
                 break;
             case FOOTER_VIEW:
                 baseViewHolder = createBaseViewHolder(mFooterLayout);
@@ -839,13 +839,19 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
 
     public void setEmptyView(View emptyView) {
         boolean insert = false;
-        if (mEmptyView == null) {
-            mEmptyView = new FrameLayout(emptyView.getContext());
-            mEmptyView.setLayoutParams(new LayoutParams(MATCH_PARENT, MATCH_PARENT));
+        if (mEmptyLayout == null) {
+            mEmptyLayout = new FrameLayout(emptyView.getContext());
+            final LayoutParams layoutParams = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
+            final ViewGroup.LayoutParams lp = emptyView.getLayoutParams();
+            if (lp != null) {
+                layoutParams.width = lp.width;
+                layoutParams.height = lp.height;
+            }
+            mEmptyLayout.setLayoutParams(layoutParams);
             insert = true;
         }
-        mEmptyView.removeAllViews();
-        mEmptyView.addView(emptyView);
+        mEmptyLayout.removeAllViews();
+        mEmptyLayout.addView(emptyView);
         mIsUseEmpty = true;
         if (insert) {
             if (getEmptyViewCount() == 1) {
@@ -894,7 +900,7 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
      * @return The view to show if the adapter is empty.
      */
     public View getEmptyView() {
-        return mEmptyView;
+        return mEmptyLayout;
     }
 
     private int mAutoLoadMoreSize = 1;

--- a/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
@@ -311,12 +311,8 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
      * @param position
      */
     public void addData(int position, T data) {
-        if (0 <= position && position < mData.size()) {
-            mData.add(position, data);
-            notifyItemInserted(position + getHeaderLayoutCount());
-        } else {
-            throw new ArrayIndexOutOfBoundsException("inserted position most greater than 0 and less than data size");
-        }
+        mData.add(position, data);
+        notifyItemInserted(position + getHeaderLayoutCount());
     }
 
     /**
@@ -333,12 +329,8 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
      * @param position
      */
     public void addData(int position, List<T> data) {
-        if (0 <= position && position < mData.size()) {
-            mData.addAll(position, data);
-            notifyItemRangeInserted(position + getHeaderLayoutCount(), data.size());
-        } else {
-            throw new ArrayIndexOutOfBoundsException("inserted position most greater than 0 and less than data size");
-        }
+        mData.addAll(position, data);
+        notifyItemRangeInserted(position + getHeaderLayoutCount(), data.size());
     }
 
     /**


### PR DESCRIPTION
1. 优化EmptyView后出现布局高度一直和父布局一致问题[#601](https://github.com/CymChad/BaseRecyclerViewAdapterHelper/issues/601)
2. 支持插入在之前布局的前面BaseQuickAdapter修改[#607](https://github.com/CymChad/BaseRecyclerViewAdapterHelper/issues/607)