### PR TITLE
判断是否开启加载更多

### DIFF
--- a/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
@@ -138,7 +138,7 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
      *
      * @return 0 or 1
      */
-    private int getLoadMoreViewCount() {
+    public int getLoadMoreViewCount() {
         if (mRequestLoadMoreListener == null || !mLoadMoreEnable) {
             return 0;
         }


### PR DESCRIPTION
修改`BaseQuickAdapter.getLoadMoreViewCount()`方法的访问修饰符为public
fix 判断BaseQuickAdapter底部有(加载状态,失败状态，加载完成End状态)[#670](https://github.com/CymChad/BaseRecyclerViewAdapterHelper/issues/670)