### PR TITLE
修改了自定义viewholder的create方式

### DIFF
--- a/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
@@ -676,7 +676,15 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
     }
 
     protected K onCreateDefViewHolder(ViewGroup parent, int viewType) {
-        return createBaseViewHolder(parent, mLayoutResId);
+        View view = getItemView(mLayoutResId, parent);
+        Class temp = getClass();
+        Class z = null;
+        while (z == null && null != temp) {
+            z = getInstancedGenericKClass(temp);
+            temp = temp.getSuperclass();
+        }
+        K k = createGenericKInstance(z, view);
+        return null != k ? k : (K) new BaseViewHolder(view);
     }
 
     protected K createBaseViewHolder(ViewGroup parent, int layoutResId) {
@@ -691,14 +699,7 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
      * @return new ViewHolder
      */
     protected K createBaseViewHolder(View view) {
-        Class temp = getClass();
-        Class z = null;
-        while (z == null && null != temp) {
-            z = getInstancedGenericKClass(temp);
-            temp = temp.getSuperclass();
-        }
-        K k = createGenericKInstance(z, view);
-        return null != k ? k : (K) new BaseViewHolder(view);
+        return (K) new BaseViewHolder(view);
     }
 
     /**


### PR DESCRIPTION
在headerview这些自带的viewholder就应该直接new就好了，只有用户有自定义viewholder时才需要用到反射，因此viewtype匹配到default的时候才走反射的create方式。
这样既不需要重写任何方法，也不需要判断是否为空。