### PR TITLE
修复当添加多个子view点击事件时，长按item会触发所有子view的点击反馈效果

### DIFF
--- a/library/src/main/java/com/chad/library/adapter/base/BaseViewHolder.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseViewHolder.java
@@ -339,6 +339,10 @@ public class BaseViewHolder extends RecyclerView.ViewHolder {
      */
     public BaseViewHolder addOnClickListener(int viewId) {
         childClickViewIds.add(viewId);
+        View view = getView(viewId);
+        if (!view.isClickable()) {
+            view.setClickable(true);
+        }
         return this;
     }
     /**
@@ -360,6 +364,10 @@ public class BaseViewHolder extends RecyclerView.ViewHolder {
      */
     public BaseViewHolder addOnLongClickListener(int viewId){
         itemChildLongClickViewIds.add(viewId);
+        View view = getView(viewId);
+        if (!view.isLongClickable()) {
+            view.setLongClickable(true);
+        }
         return this;
     }
 


### PR DESCRIPTION
通过`addOnLongClickListener`添加多个child item点击事件时，长按其中一个，所有child item都会触发点击反馈效果。
原因是：本例通过`setPressed`设置时，`ViewGroup`会通过`dispatchSetPressed`分发点击状态，`dispatchSetPressed`中判断如果child没有clickable标识时则同时分发至child view。
通过设置child item为clickable/longClickable，可以阻止该状态分发。