### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -16,7 +16,7 @@
 ## Google Play Demo
 
 [![Get it on Google Play](https://developer.android.com/images/brand/en_generic_rgb_wo_60.png)](https://play.google.com/store/apps/details?id=com.chad.baserecyclerviewadapterhelper)
-#它能做什么？（[下载 apk](https://github.com/CymChad/BaseRecyclerViewAdapterHelper/raw/master/demo_res/demo.apk)）
+# 它能做什么？（[下载 apk](https://github.com/CymChad/BaseRecyclerViewAdapterHelper/raw/master/demo_res/demo.apk)）
 - **优化Adapter代码（减少百分之70%代码）**
 - **添加点击item点击、长按事件、以及item子控件的点击事件**
 - **添加加载动画（一行代码轻松切换5种默认动画）**
@@ -27,9 +27,9 @@
 - **设置空布局（比Listview的setEmptyView还要好用！）**
 - **添加拖拽item**
 
-#扩展库
+# 扩展库
 [PinnedSectionItemDecoration](https://github.com/oubowu/PinnedSectionItemDecoration)
-#如何使用它？
+# 如何使用它？
 先在 build.gradle 的 repositories 添加:
 ```
 	allprojects {
@@ -46,7 +46,7 @@
 	}
 ```
 
-#如何使用它来创建Adapter？
+# 如何使用它来创建Adapter？
 ![demo](https://github.com/CymChad/BaseRecyclerViewAdapterHelper/blob/master/demo_res/item_view.png)
 ```java
 public class QuickAdapter extends BaseQuickAdapter<Status> {
@@ -77,8 +77,8 @@ mRecyclerView.addOnItemTouchListener(new OnItemClickListener( ){
         });
         
 ```
-#设置 item  click  新增添加子布局多个控件的点击事件
-#设置 it item child click
+# 设置 item  click  新增添加子布局多个控件的点击事件
+# 设置 it item child click
 首先需要添加需要点击触发的 childview id 
 ``` 
  @Override
@@ -104,7 +104,7 @@ Activity
             }
         });
 ```
-#设置 it item long click
+# 设置 it item long click
 ```java
  mRecyclerView.addOnItemTouchListener(new OnItemLongClickListener( ) {
             @Override
@@ -114,7 +114,7 @@ Activity
             }
         });
 ```
-#设置 it item child long click
+# 设置 it item child long click
 首先需要添加需要点击触发的 childview id 
 ``` 
  @Override
@@ -165,7 +165,7 @@ Activity
 ``` 
 
 
-#如何使用它添加动画？
+# 如何使用它添加动画？
 ![demo](https://github.com/CymChad/BaseRecyclerViewAdapterHelper/blob/master/demo_res/animation.gif)
 ```java
 // 一行代码搞定（默认为渐显效果）
@@ -189,7 +189,7 @@ quickAdapter.openLoadAnimation(new BaseAnimation() {
                             }
                         });
 ```
-#使用它添加头部添加尾部
+# 使用它添加头部添加尾部
 ![demo](https://github.com/CymChad/BaseRecyclerViewAdapterHelper/blob/master/demo_res/header_footer.gif)
 ```java
 // add
@@ -202,7 +202,7 @@ removeFooterView(getView);
 removeAllHeaderView();
 removeAllFooterView();
 ```
-#使用它加载更多
+# 使用它加载更多
 ![demo](https://github.com/CymChad/BaseRecyclerViewAdapterHelper/blob/master/demo_res/load_more.gif)
 ```java
 mQuickAdapter.openLoadMore(PAGE_SIZE, true);
@@ -224,11 +224,11 @@ mQuickAdapter.setOnLoadMoreListener(new BaseQuickAdapter.RequestLoadMoreListener
             }
         });
 ```
-#设置自定义加载更多布局
+# 设置自定义加载更多布局
 ```java
 mQuickAdapter.setLoadingView(customView);
 ```
-#使用分组
+# 使用分组
 ![demo](https://github.com/CymChad/BaseRecyclerViewAdapterHelper/blob/master/demo_res/section_headers.gif)
 ```java
 public class SectionAdapter extends BaseSectionQuickAdapter<MySection> {
@@ -251,7 +251,7 @@ public class SectionAdapter extends BaseSectionQuickAdapter<MySection> {
         });
     }
 ```
-#如何添加多种类型item？
+# 如何添加多种类型item？
 ![demo](https://github.com/CymChad/BaseRecyclerViewAdapterHelper/blob/master/demo_res/multiple_item.gif)
 ```java
 public class MultipleItemQuickAdapter extends BaseMultiItemQuickAdapter<MultipleItem> {
@@ -276,12 +276,12 @@ public class MultipleItemQuickAdapter extends BaseMultiItemQuickAdapter<Multiple
 
 }
 ```
-#使用setEmptyView
+# 使用setEmptyView
 ![demo](https://github.com/CymChad/BaseRecyclerViewAdapterHelper/blob/master/demo_res/empty_view.gif)
 ```java
 mQuickAdapter.setEmptyView(getView());
 ```
-#使用拖拽与滑动删除
+# 使用拖拽与滑动删除
 ![demo](https://github.com/CymChad/BaseRecyclerViewAdapterHelper/blob/master/demo_res/drag_item.gif)
 ```java
 OnItemDragListener onItemDragListener = new OnItemDragListener() {
@@ -328,7 +328,7 @@ mAdapter.enableSwipeItem();
 mAdapter.setOnItemSwipeListener(onItemSwipeListener);
 ```
 
-#Expandable Item
+# Expandable Item
 ![demo](https://github.com/CymChad/BaseRecyclerViewAdapterHelper/blob/master/demo_res/expandable_item.gif)
 ```Java
 // 如果不想使用继承，可以只实现IExpandable接口
@@ -414,5 +414,5 @@ protected K createBaseViewHolder(View view) {
 
 >**持续更新!，所以推荐Star项目**
 
-#感谢
+# 感谢
 [JoanZapata / base-adapter-helper](https://github.com/JoanZapata/base-adapter-helper)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
