### PR TITLE
import annotation.ResLayout lib

### DIFF
--- a/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
@@ -19,6 +19,7 @@ import android.animation.Animator;
 import android.content.Context;
 import android.support.annotation.IntDef;
 import android.support.annotation.IntRange;
+import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.GridLayoutManager;


### PR DESCRIPTION
someone added annotation in BaseQuickAdapter but forgot add annotation lib in v2.9.13.
it caused compiling error
![wechatimg6](https://cloud.githubusercontent.com/assets/8605787/25329964/7ee6a924-2910-11e7-9067-0086b38ac981.jpeg)
