### PR TITLE
支持baseviewholder带泛型参数

### DIFF
--- a/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
@@ -749,6 +749,11 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
                     if (BaseViewHolder.class.isAssignableFrom(tempClass)) {
                         return tempClass;
                     }
+                } else if (temp instanceof ParameterizedType) {
+                    Type rawType = ((ParameterizedType) temp).getRawType();
+                    if (rawType instanceof Class && BaseViewHolder.class.isAssignableFrom((Class<?>) rawType)) {
+                        return (Class<?>) rawType;
+                    }
                 }
             }
         }


### PR DESCRIPTION
支持baseviewholder带泛型参数 （如果我的viewholder需要利用泛型，按照原来的代码是不能够支持这个功能的）