### PR TITLE
增加兼容emptyView高度的方法 setCompatEmptyHeight()

### DIFF
--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/EmptyViewUseActivity.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/EmptyViewUseActivity.java
@@ -48,7 +48,14 @@ public class EmptyViewUseActivity extends BaseActivity implements View.OnClickLi
 
     private void initAdapter() {
         mQuickAdapter = new QuickAdapter(0);
+        mQuickAdapter.bindToRecyclerView(mRecyclerView);
+        mQuickAdapter.setHeaderFooterEmpty(true, true);
+        mQuickAdapter.setCompatEmptyHeight(true);
         mRecyclerView.setAdapter(mQuickAdapter);
+
+        mQuickAdapter.addHeaderView(getLayoutInflater().inflate(R.layout.head_view, (ViewGroup) mRecyclerView.getParent(), false));
+        mQuickAdapter.addFooterView(getLayoutInflater().inflate(R.layout.footer_view, (ViewGroup) mRecyclerView.getParent(), false), 0);
+
     }
 
     @Override

--- a/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
@@ -1348,6 +1348,23 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
         return -1;
     }
 
+    public void setEmptyView(int layoutResId, ViewGroup viewGroup) {
+        View view = LayoutInflater.from(viewGroup.getContext()).inflate(layoutResId, viewGroup, false);
+        setEmptyView(view);
+    }
+
+    /**
+     * bind recyclerView {@link #bindToRecyclerView(RecyclerView)} before use!
+     * Recommend you to use {@link #setEmptyView(layoutResId, viewGroup)}
+     *
+     * @see #bindToRecyclerView(RecyclerView)
+     */
+    @Deprecated
+    public void setEmptyView(int layoutResId) {
+        checkNotNull();
+        setEmptyView(layoutResId, getRecyclerView());
+    }
+
     public void setEmptyView(final View emptyView) {
         boolean insert = false;
         if (mEmptyLayout == null) {
@@ -1389,8 +1406,8 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
             }
             mEmptyLayout.setLayoutParams(layoutParams);
             insert = true;
-
         }
+
         mEmptyLayout.removeAllViews();
         mEmptyLayout.addView(emptyView);
         mIsUseEmpty = true;
@@ -1403,23 +1420,6 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
                 notifyItemInserted(position);
             }
         }
-    }
-
-    public void setEmptyView(int layoutResId, ViewGroup viewGroup) {
-        View view = LayoutInflater.from(viewGroup.getContext()).inflate(layoutResId, viewGroup, false);
-        setEmptyView(view);
-    }
-
-    /**
-     * bind recyclerView {@link #bindToRecyclerView(RecyclerView)} before use!
-     * Recommend you to use {@link #setEmptyView(layoutResId, viewGroup)}
-     *
-     * @see #bindToRecyclerView(RecyclerView)
-     */
-    @Deprecated
-    public void setEmptyView(int layoutResId) {
-        checkNotNull();
-        setEmptyView(layoutResId, getRecyclerView());
     }
 
     /**


### PR DESCRIPTION
让 `headerView` , `footerView` , `emptyView` 可以在一屏全部显示出来

- 之前
![image](https://user-images.githubusercontent.com/7357841/39504065-d4d3c720-4dfb-11e8-9ff8-244059f642be.png)

- 设置`mQuickAdapter.setCompatEmptyHeight(true);` 后
![image](https://user-images.githubusercontent.com/7357841/39503986-683dfd42-4dfb-11e8-8def-909667ebf23c.png)




