### PR TITLE
滑动删除完成的监听的错误。

### DIFF
--- a/library/src/main/java/com/chad/library/adapter/base/BaseItemDraggableAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseItemDraggableAdapter.java
@@ -239,15 +239,13 @@ public abstract class BaseItemDraggableAdapter<T, K extends BaseViewHolder> exte
     }
 
     public void onItemSwiped(RecyclerView.ViewHolder viewHolder) {
-        if (mOnItemSwipeListener != null && itemSwipeEnabled) {
-            mOnItemSwipeListener.onItemSwiped(viewHolder, getViewHolderPosition(viewHolder));
-        }
-
         int pos = getViewHolderPosition(viewHolder);
-
         if (inRange(pos)) {
             mData.remove(pos);
             notifyItemRemoved(viewHolder.getAdapterPosition());
+        }
+         if (mOnItemSwipeListener != null && itemSwipeEnabled) {
+            mOnItemSwipeListener.onItemSwiped(viewHolder, getViewHolderPosition(viewHolder));
         }
     }
 


### PR DESCRIPTION
当onItemSwiped方法回调前，数据源没有删掉该item，导致在回调方法中，得到的为移除前的数据。