### PR TITLE
fix issue #2596

### DIFF
--- a/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
@@ -1792,6 +1792,11 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
                 int pos = getItemPosition(subItem);
                 if (pos < 0) {
                     continue;
+                } else if (pos < position) {
+                    pos = position + i + 1;
+                    if (pos >= mData.size()) {
+                        continue;
+                    }
                 }
                 if (subItem instanceof IExpandable) {
                     subItemCount += recursiveCollapse(pos);


### PR DESCRIPTION
有些场景下mData中的不同位置会引用同一个数据对象，这样就会导致collapse的时候只会remove掉第一个位置的引用，而本应该被remove的位置却还保留着，导致异常--已修复