### PR TITLE
fix the bug that apdapter delay to call setOnItemClickListener() that…

### DIFF
--- a/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
@@ -74,6 +74,7 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
     private LoadMoreView mLoadMoreView = new SimpleLoadMoreView();
     private RequestLoadMoreListener mRequestLoadMoreListener;
     private boolean mEnableLoadMoreEndClick = false;
+    private List<K> mViewHolders;
 
     //Animation
     /**
@@ -476,6 +477,7 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
         if (layoutResId != 0) {
             this.mLayoutResId = layoutResId;
         }
+        mViewHolders = new ArrayList<>();
     }
 
     public BaseQuickAdapter(@Nullable List<T> data) {
@@ -780,6 +782,7 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
             default:
                 baseViewHolder = onCreateDefViewHolder(parent, viewType);
                 bindViewClickListener(baseViewHolder);
+                mViewHolders.add(baseViewHolder);
         }
         baseViewHolder.setAdapter(this);
         return baseViewHolder;
@@ -963,23 +966,22 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
         if (view == null) {
             return;
         }
-        view.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (getOnItemClickListener() != null) {
+        if (getOnItemClickListener() != null) {
+            view.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
                     setOnItemClick(v, baseViewHolder.getLayoutPosition() - getHeaderLayoutCount());
                 }
-            }
-        });
-        view.setOnLongClickListener(new View.OnLongClickListener() {
-            @Override
-            public boolean onLongClick(View v) {
-                if (getOnItemLongClickListener() != null) {
+            });
+        }
+        if (getOnItemLongClickListener() != null) {
+            view.setOnLongClickListener(new View.OnLongClickListener() {
+                @Override
+                public boolean onLongClick(View v) {
                     return setOnItemLongClick(v, baseViewHolder.getLayoutPosition() - getHeaderLayoutCount());
                 }
-                return false;
-            }
-        });
+            });
+        }
     }
 
     /**
@@ -2001,6 +2003,9 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
      */
     public void setOnItemClickListener(@Nullable OnItemClickListener listener) {
         mOnItemClickListener = listener;
+        for (BaseViewHolder b : mViewHolders) {
+            bindViewClickListener(b);
+        }
     }
 
     /**

--- a/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
@@ -963,22 +963,23 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
         if (view == null) {
             return;
         }
-        if (getOnItemClickListener() != null) {
-            view.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
+        view.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (getOnItemClickListener() != null) {
                     setOnItemClick(v, baseViewHolder.getLayoutPosition() - getHeaderLayoutCount());
                 }
-            });
-        }
-        if (getOnItemLongClickListener() != null) {
-            view.setOnLongClickListener(new View.OnLongClickListener() {
-                @Override
-                public boolean onLongClick(View v) {
+            }
+        });
+        view.setOnLongClickListener(new View.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View v) {
+                if (getOnItemLongClickListener() != null) {
                     return setOnItemLongClick(v, baseViewHolder.getLayoutPosition() - getHeaderLayoutCount());
                 }
-            });
-        }
+                return false;
+            }
+        });
     }
 
     /**
@@ -1152,7 +1153,7 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
      * @param index
      * @param orientation
      */
-    public int addHeaderView(View header,final int index, int orientation) {
+    public int addHeaderView(View header, final int index, int orientation) {
         if (mHeaderLayout == null) {
             mHeaderLayout = new LinearLayout(header.getContext());
             if (orientation == LinearLayout.VERTICAL) {
@@ -1164,7 +1165,7 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
             }
         }
         final int childCount = mHeaderLayout.getChildCount();
-        int mIndex =index;
+        int mIndex = index;
         if (index < 0 || index > childCount) {
             mIndex = childCount;
         }
@@ -1930,6 +1931,7 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
     public interface OnItemChildClickListener {
         /**
          * callback method to be invoked when an itemchild in this view has been click
+         *
          * @param adapter
          * @param view     The view whihin the ItemView that was clicked
          * @param position The position of the view int the adapter
@@ -1946,6 +1948,7 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
         /**
          * callback method to be invoked when an item in this view has been
          * click and held
+         *
          * @param adapter  this BaseQuickAdapter adapter
          * @param view     The childView whihin the itemView that was clicked and held.
          * @param position The position of the view int the adapter

--- a/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
@@ -2003,8 +2003,8 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
      */
     public void setOnItemClickListener(@Nullable OnItemClickListener listener) {
         mOnItemClickListener = listener;
-        for (BaseViewHolder b : mViewHolders) {
-            bindViewClickListener(b);
+        for (BaseViewHolder viewHolder : mViewHolders) {
+            bindViewClickListener(viewHolder);
         }
     }
 
@@ -2026,6 +2026,9 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
      */
     public void setOnItemLongClickListener(OnItemLongClickListener listener) {
         mOnItemLongClickListener = listener;
+        for (BaseViewHolder viewHolder : mViewHolders) {
+            bindViewClickListener(viewHolder);
+        }
     }
 
     /**

--- a/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
@@ -970,7 +970,9 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
             view.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    setOnItemClick(v, baseViewHolder.getLayoutPosition() - getHeaderLayoutCount());
+                    if (getOnItemClickListener() != null) {
+                        setOnItemClick(v, baseViewHolder.getLayoutPosition() - getHeaderLayoutCount());
+                    }
                 }
             });
         }
@@ -978,7 +980,9 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
             view.setOnLongClickListener(new View.OnLongClickListener() {
                 @Override
                 public boolean onLongClick(View v) {
-                    return setOnItemLongClick(v, baseViewHolder.getLayoutPosition() - getHeaderLayoutCount());
+                    if (getOnItemLongClickListener() != null)
+                        return setOnItemLongClick(v, baseViewHolder.getLayoutPosition() - getHeaderLayoutCount());
+                    return false;
                 }
             });
         }


### PR DESCRIPTION
Some codes like this:
``` java
        //MyAdpater extent BaseQuickAdapter
        MyAdapter adapter = new MyAdapter(R.layout.item, list);
        LinearLayoutManager layoutManager = new LinearLayoutManager(this);
        recyclerView.setLayoutManager(layoutManager);
        recyclerView.setAdapter(adapter);
        new Thread(new Runnable() {
            @Override
            public void run() {
                try {
                    Thread.sleep(10000);
                } catch (InterruptedException e) {
                    e.printStackTrace();
                }
                adapter.setOnItemClickListener((adapter12, view, position) -> Log.d("ApplicantActivity", list.get(position)));
                adapter.setOnItemLongClickListener((adapter1, view, position) -> {
                    Toast.makeText(ApplicantActivity.this, "long click: " + list.get(position), Toast.LENGTH_SHORT).show();
                    return true;
                });

            }
        }).start();
```
In this codes, the item click event will failure because item view didn't execute the setOnClickListener() function.
The codes are no meaning. But the bug will appear if the recycleview have loaded end that adpater call setOnItemClickListener().
I modify the logic of bindViewClickListener() function to solve this problem.