### PR TITLE
fix setEmptyView crash because mHeadAndEmptyEnable, mFootAndEmptyEnab…

### DIFF
--- a/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
@@ -1370,6 +1370,7 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
     }
 
     public void setEmptyView(View emptyView) {
+        int oldItemCount = getItemCount();
         boolean insert = false;
         if (mEmptyLayout == null) {
             mEmptyLayout = new FrameLayout(emptyView.getContext());
@@ -1390,7 +1391,11 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
             if (mHeadAndEmptyEnable && getHeaderLayoutCount() != 0) {
                 position++;
             }
-            notifyItemInserted(position);
+            if (getItemCount() > oldItemCount) {
+                notifyItemInserted(position);
+            } else {
+                notifyDataSetChanged();
+            }
         }
     }
 


### PR DESCRIPTION
fix setEmptyView crash because mHeadAndEmptyEnable, mFootAndEmptyEnable, setEmptyView may not change itemCount.