### PR TITLE
修复 BaseMultiItemQuickAdapter 有 headerLayout 但是没有 subItem 的情况下，点击 item 展开崩溃的问题

### DIFF
--- a/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.java
@@ -1809,7 +1809,7 @@ public abstract class BaseQuickAdapter<T, K extends BaseViewHolder> extends Recy
         }
         if (!hasSubItems(expandable)) {
             expandable.setExpanded(true);
-            notifyItemChanged(position);
+            notifyItemChanged(position + getHeaderLayoutCount());
             return 0;
         }
         int subItemCount = 0;


### PR DESCRIPTION
修复 BaseMultiItemQuickAdapter 有 headerLayout 但是没有 subItem 的情况下，点击 item , 在 onItemClickListener 中执行 expands() 会导致崩溃的问题

崩溃日志如下：

```
java.lang.IllegalArgumentException
Called attach on a child which is not detached: ViewHolder{3464148 position=0 id=-1, oldPos=-1, pLpos:-1} androidx.recyclerview.widget.RecyclerView
androidx.recyclerview.widget.RecyclerView$5.attachViewToParent(RecyclerView.java:915)
...
```