### PR TITLE
修改BaseNodeAdapter收起时删除超多数据量卡顿问题

### DIFF
--- a/library/src/main/java/com/chad/library/adapter/base/BaseNodeAdapter.kt
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseNodeAdapter.kt
@@ -432,7 +432,12 @@ abstract class BaseNodeAdapter(nodeList: MutableList<BaseNode>? = null)
             }
             val items = flatData(node.childNode!!, if (isChangeChildCollapse) false else null)
             val size = items.size
-            this.data.removeAll(items)
+//            this.data.removeAll(items)
+            //修改移除方法解决删除大数据卡顿问题
+            this.data.subList(
+                    position + 1,
+                    position + 1 + size
+            ).clear()
             if (notify) {
                 if (animate) {
                     notifyItemChanged(adapterPosition, parentPayload)


### PR DESCRIPTION
当折叠类型的adapter二级视图添加几十万个数据时,收起时会因为this.data.removeAll(items)耗时严重导致出现卡死问题