### PR TITLE
仅在明确需要的场景下允许item为空, fix #3793

### DIFF
--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/animation/adapter/AnimationAdapter.kt
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/animation/adapter/AnimationAdapter.kt
@@ -35,7 +35,7 @@ class AnimationAdapter :
         return QuickViewHolder(R.layout.layout_animation, parent)
     }
 
-    override fun onBindViewHolder(holder: QuickViewHolder, position: Int, item: Status?) {
+    override fun onBindViewHolder(holder: QuickViewHolder, position: Int, item: Status) {
         when (holder.layoutPosition % 3) {
             0 -> holder.setImageResource(R.id.img, R.mipmap.animation_img1)
             1 -> holder.setImageResource(R.id.img, R.mipmap.animation_img2)

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/databinding/adapter/DataBindingAdapter.java
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/databinding/adapter/DataBindingAdapter.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.chad.baserecyclerviewadapterhelper.R;
 import com.chad.baserecyclerviewadapterhelper.databinding.ItemMovieBinding;
@@ -30,9 +29,7 @@ public class DataBindingAdapter extends BaseQuickAdapter<Movie, DataBindingHolde
     }
 
     @Override
-    protected void onBindViewHolder(@NonNull DataBindingHolder<ItemMovieBinding> holder, int position, @Nullable Movie item) {
-        if (item == null) return;
-
+    protected void onBindViewHolder(@NonNull DataBindingHolder<ItemMovieBinding> holder, int position, @NonNull Movie item) {
         // 获取 Binding
         ItemMovieBinding binding = holder.getBinding();
         binding.setMovie(item);

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/dragswipe/adapter/DiffDragAndSwipeAdapter.kt
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/dragswipe/adapter/DiffDragAndSwipeAdapter.kt
@@ -23,8 +23,6 @@ class DiffDragAndSwipeAdapter :
     override fun onBindViewHolder(
         holder: QuickViewHolder, position: Int, item: DiffEntity
     ) {
-        if (item == null) return
-
         holder.setText(R.id.tweetName, item.title)
             .setText(R.id.tweetText, item.content)
             .setText(R.id.tweetDate, item.date)

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/dragswipe/adapter/DiffDragAndSwipeAdapter.kt
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/dragswipe/adapter/DiffDragAndSwipeAdapter.kt
@@ -21,7 +21,7 @@ class DiffDragAndSwipeAdapter :
     }
 
     override fun onBindViewHolder(
-        holder: QuickViewHolder, position: Int, item: DiffEntity?
+        holder: QuickViewHolder, position: Int, item: DiffEntity
     ) {
         if (item == null) return
 

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/dragswipe/adapter/HeaderDragAndSwipeAdapter.kt
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/dragswipe/adapter/HeaderDragAndSwipeAdapter.kt
@@ -21,7 +21,7 @@ open class HeaderDragAndSwipeAdapter : BaseQuickAdapter<String, QuickViewHolder>
         return QuickViewHolder(R.layout.item_draggable_view, parent)
     }
 
-     override fun onBindViewHolder(holder: QuickViewHolder, position: Int, item: String?) {
+     override fun onBindViewHolder(holder: QuickViewHolder, position: Int, item: String) {
         when (holder.layoutPosition % 3) {
             0 -> holder.setImageResource(R.id.iv_head, R.mipmap.head_img0)
             1 -> holder.setImageResource(R.id.iv_head, R.mipmap.head_img1)

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/emptyview/adapter/EmptyViewAdapter.kt
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/emptyview/adapter/EmptyViewAdapter.kt
@@ -22,7 +22,7 @@ class EmptyViewAdapter : BaseQuickAdapter<Status, EmptyViewAdapter.VH>() {
         return VH(parent)
     }
 
-     override fun onBindViewHolder(holder: VH, position: Int, item: Status?) {
+     override fun onBindViewHolder(holder: VH, position: Int, item: Status) {
         when (holder.layoutPosition % 3) {
             0 -> holder.binding.img.setImageResource(R.mipmap.animation_img1)
             1 -> holder.binding.img.setImageResource(R.mipmap.animation_img2)

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/headerfooter/adapter/FooterAdapter.kt
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/headerfooter/adapter/FooterAdapter.kt
@@ -3,18 +3,22 @@ package com.chad.baserecyclerviewadapterhelper.activity.headerfooter.adapter
 import android.content.Context
 import android.view.ViewGroup
 import com.chad.baserecyclerviewadapterhelper.R
-import com.chad.library.adapter.base.BaseSingleItemAdapter
+import com.chad.library.adapter.base.SimpleSingleItemAdapter
 import com.chad.library.adapter.base.viewholder.QuickViewHolder
 
 class FooterAdapter(
     private val isDelete: Boolean
-) : BaseSingleItemAdapter<Any?, QuickViewHolder>(null) {
+) : SimpleSingleItemAdapter<QuickViewHolder>() {
 
-    override fun onCreateViewHolder(context: Context, parent: ViewGroup, viewType: Int): QuickViewHolder {
+    override fun onCreateViewHolder(
+        context: Context,
+        parent: ViewGroup,
+        viewType: Int
+    ): QuickViewHolder {
         return QuickViewHolder(R.layout.footer_view, parent)
     }
 
-    override fun onBindViewHolder(holder: QuickViewHolder, item: Any?) {
+    override fun onBindViewHolder(holder: QuickViewHolder) {
         if (isDelete) {
             holder.setImageResource(R.id.iv, R.mipmap.rm_icon)
         }

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/headerfooter/adapter/FooterAdapter.kt
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/headerfooter/adapter/FooterAdapter.kt
@@ -8,7 +8,7 @@ import com.chad.library.adapter.base.viewholder.QuickViewHolder
 
 class FooterAdapter(
     private val isDelete: Boolean
-) : BaseSingleItemAdapter<Any, QuickViewHolder>() {
+) : BaseSingleItemAdapter<Any?, QuickViewHolder>(null) {
 
     override fun onCreateViewHolder(context: Context, parent: ViewGroup, viewType: Int): QuickViewHolder {
         return QuickViewHolder(R.layout.footer_view, parent)

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/headerfooter/adapter/HeaderAdapter.kt
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/headerfooter/adapter/HeaderAdapter.kt
@@ -6,18 +6,16 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.chad.baserecyclerviewadapterhelper.R
-import com.chad.library.adapter.base.BaseSingleItemAdapter
+import com.chad.library.adapter.base.SimpleSingleItemAdapter
 
-class HeaderAdapter: BaseSingleItemAdapter<Any?, HeaderAdapter.VH>(null) {
+class HeaderAdapter : SimpleSingleItemAdapter<HeaderAdapter.VH>() {
 
-    class VH(view: View): RecyclerView.ViewHolder(view)
+    class VH(view: View) : RecyclerView.ViewHolder(view)
 
     override fun onCreateViewHolder(context: Context, parent: ViewGroup, viewType: Int): VH {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.head_view, parent, false)
         return VH(view)
     }
 
-    override fun onBindViewHolder(holder: VH, item: Any?) {
-
-    }
+    override fun onBindViewHolder(holder: VH) {}
 }

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/headerfooter/adapter/HeaderAdapter.kt
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/headerfooter/adapter/HeaderAdapter.kt
@@ -16,6 +16,4 @@ class HeaderAdapter : SimpleSingleItemAdapter<HeaderAdapter.VH>() {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.head_view, parent, false)
         return VH(view)
     }
-
-    override fun onBindViewHolder(holder: VH) {}
 }

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/headerfooter/adapter/HeaderAdapter.kt
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/headerfooter/adapter/HeaderAdapter.kt
@@ -8,7 +8,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.chad.baserecyclerviewadapterhelper.R
 import com.chad.library.adapter.base.BaseSingleItemAdapter
 
-class HeaderAdapter: BaseSingleItemAdapter<Any, HeaderAdapter.VH>() {
+class HeaderAdapter: BaseSingleItemAdapter<Any?, HeaderAdapter.VH>(null) {
 
     class VH(view: View): RecyclerView.ViewHolder(view)
 

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/home/adapter/HomeAdapter.kt
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/home/adapter/HomeAdapter.kt
@@ -27,8 +27,7 @@ class HomeAdapter(data: List<HomeEntity>) : BaseMultiItemAdapter<HomeEntity>(dat
                 return ItemVH(viewBinding)
             }
 
-            override fun onBind(holder: ItemVH, position: Int, item: HomeEntity?) {
-                if (item == null) return
+            override fun onBind(holder: ItemVH, position: Int, item: HomeEntity) {
                 holder.viewBinding.textView.text = item.name
                 holder.viewBinding.icon.setImageResource(item.imageResource)
             }
@@ -39,9 +38,7 @@ class HomeAdapter(data: List<HomeEntity>) : BaseMultiItemAdapter<HomeEntity>(dat
                 return HeaderVH(viewBinding)
             }
 
-            override fun onBind(holder: HeaderVH, position: Int, item: HomeEntity?) {
-                if (item == null) return
-
+            override fun onBind(holder: HeaderVH, position: Int, item: HomeEntity) {
                 holder.viewBinding.more.visibility = View.GONE
                 holder.viewBinding.header.text = item.sectionTitle
             }

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/home/adapter/HomeTopHeaderAdapter.kt
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/home/adapter/HomeTopHeaderAdapter.kt
@@ -22,8 +22,6 @@ class HomeTopHeaderAdapter : SimpleSingleItemAdapter<HomeTopHeaderAdapter.VH>(),
         return VH(LayoutInflater.from(parent.context).inflate(R.layout.top_view, parent, false))
     }
 
-    override fun onBindViewHolder(holder: VH) {}
-
     override fun getItemViewType(position: Int, list: List<Any?>): Int {
         return HEAD_VIEWTYPE
     }

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/home/adapter/HomeTopHeaderAdapter.kt
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/home/adapter/HomeTopHeaderAdapter.kt
@@ -9,7 +9,7 @@ import com.chad.baserecyclerviewadapterhelper.R
 import com.chad.library.adapter.base.BaseSingleItemAdapter
 import com.chad.library.adapter.base.fullspan.FullSpanAdapterType
 
-class HomeTopHeaderAdapter : BaseSingleItemAdapter<Any, HomeTopHeaderAdapter.VH>(), FullSpanAdapterType {
+class HomeTopHeaderAdapter : BaseSingleItemAdapter<Any?, HomeTopHeaderAdapter.VH>(null), FullSpanAdapterType {
 
     companion object {
         val HEAD_VIEWTYPE = 0x10000556
@@ -21,8 +21,7 @@ class HomeTopHeaderAdapter : BaseSingleItemAdapter<Any, HomeTopHeaderAdapter.VH>
         return VH(LayoutInflater.from(parent.context).inflate(R.layout.top_view, parent, false))
     }
 
-    override fun onBindViewHolder(holder: VH, item: Any?) {
-    }
+    override fun onBindViewHolder(holder: VH, item: Any?) { }
 
     override fun getItemViewType(position: Int, list: List<Any?>): Int {
         return HEAD_VIEWTYPE

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/home/adapter/HomeTopHeaderAdapter.kt
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/home/adapter/HomeTopHeaderAdapter.kt
@@ -6,10 +6,11 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.chad.baserecyclerviewadapterhelper.R
-import com.chad.library.adapter.base.BaseSingleItemAdapter
+import com.chad.library.adapter.base.SimpleSingleItemAdapter
 import com.chad.library.adapter.base.fullspan.FullSpanAdapterType
 
-class HomeTopHeaderAdapter : BaseSingleItemAdapter<Any?, HomeTopHeaderAdapter.VH>(null), FullSpanAdapterType {
+class HomeTopHeaderAdapter : SimpleSingleItemAdapter<HomeTopHeaderAdapter.VH>(),
+    FullSpanAdapterType {
 
     companion object {
         val HEAD_VIEWTYPE = 0x10000556
@@ -21,7 +22,7 @@ class HomeTopHeaderAdapter : BaseSingleItemAdapter<Any?, HomeTopHeaderAdapter.VH
         return VH(LayoutInflater.from(parent.context).inflate(R.layout.top_view, parent, false))
     }
 
-    override fun onBindViewHolder(holder: VH, item: Any?) { }
+    override fun onBindViewHolder(holder: VH) {}
 
     override fun getItemViewType(position: Int, list: List<Any?>): Int {
         return HEAD_VIEWTYPE

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/loadmore/adapter/RecyclerViewAdapter.kt
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/loadmore/adapter/RecyclerViewAdapter.kt
@@ -34,7 +34,7 @@ class RecyclerViewAdapter : BaseQuickAdapter<Status, RecyclerViewAdapter.VH>() {
         return VH(parent)
     }
 
-    protected override fun onBindViewHolder(holder: VH, position: Int, item: Status?) {
+    protected override fun onBindViewHolder(holder: VH, position: Int, item: Status) {
         when (holder.layoutPosition % 3) {
             0 -> holder.viewBinding.img.setImageResource(R.mipmap.animation_img1)
             1 -> holder.viewBinding.img.setImageResource(R.mipmap.animation_img2)

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/scene/adapter/GroupAdapter.kt
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/scene/adapter/GroupAdapter.kt
@@ -28,7 +28,7 @@ class GroupAdapter : BaseQuickAdapter<GroupDemoEntity.Group, GroupAdapter.VH>(){
         return VH(parent)
     }
 
-    override fun onBindViewHolder(holder: VH, position: Int, item: GroupDemoEntity.Group?) {
+    override fun onBindViewHolder(holder: VH, position: Int, item: GroupDemoEntity.Group) {
         if (item == null) return
 
         holder.binding.tvTitle.text = item.title

--- a/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/scene/adapter/GroupAdapter.kt
+++ b/app/src/main/java/com/chad/baserecyclerviewadapterhelper/activity/scene/adapter/GroupAdapter.kt
@@ -29,8 +29,6 @@ class GroupAdapter : BaseQuickAdapter<GroupDemoEntity.Group, GroupAdapter.VH>(){
     }
 
     override fun onBindViewHolder(holder: VH, position: Int, item: GroupDemoEntity.Group) {
-        if (item == null) return
-
         holder.binding.tvTitle.text = item.title
         holder.binding.tvContent.text = item.content
 

--- a/library/src/main/java/com/chad/library/adapter/base/BaseMultiItemAdapter.kt
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseMultiItemAdapter.kt
@@ -31,12 +31,12 @@ abstract class BaseMultiItemAdapter<T>(items: List<T> = emptyList()) :
         }
     }
 
-    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int, item: T?) {
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int, item: T) {
         findListener(holder)?.onBind(holder, position, item)
     }
 
     override fun onBindViewHolder(
-        holder: RecyclerView.ViewHolder, position: Int, item: T?, payloads: List<Any>
+        holder: RecyclerView.ViewHolder, position: Int, item: T, payloads: List<Any>
     ) {
         if (payloads.isEmpty()) {
             onBindViewHolder(holder, position, item)

--- a/library/src/main/java/com/chad/library/adapter/base/BaseMultiItemAdapter.kt
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseMultiItemAdapter.kt
@@ -115,9 +115,9 @@ abstract class BaseMultiItemAdapter<T>(items: List<T> = emptyList()) :
     interface OnMultiItemAdapterListener<T, V : RecyclerView.ViewHolder> {
         fun onCreate(context: Context, parent: ViewGroup, viewType: Int): V
 
-        fun onBind(holder: V, position: Int, item: T?)
+        fun onBind(holder: V, position: Int, item: T)
 
-        fun onBind(holder: V, position: Int, item: T?, payloads: List<Any>) {
+        fun onBind(holder: V, position: Int, item: T, payloads: List<Any>) {
             onBind(holder, position, item)
         }
 

--- a/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.kt
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.kt
@@ -148,7 +148,7 @@ abstract class BaseQuickAdapter<T, VH : RecyclerView.ViewHolder>(
      * @param holder A fully initialized helper.
      * @param item   The item that needs to be displayed.
      */
-    protected abstract fun onBindViewHolder(holder: VH, position: Int, item: T?)
+    protected abstract fun onBindViewHolder(holder: VH, position: Int, item: T)
 
     /**
      * Optional implementation this method and use the helper to adapt the view to the given item.
@@ -162,7 +162,7 @@ abstract class BaseQuickAdapter<T, VH : RecyclerView.ViewHolder>(
      * @param item     The item that needs to be displayed.
      * @param payloads payload info.
      */
-    protected open fun onBindViewHolder(holder: VH, position: Int, item: T?, payloads: List<Any>) {
+    protected open fun onBindViewHolder(holder: VH, position: Int, item: T, payloads: List<Any>) {
         onBindViewHolder(holder, position, item)
     }
 
@@ -397,13 +397,13 @@ abstract class BaseQuickAdapter<T, VH : RecyclerView.ViewHolder>(
 
     /**
      * Get the data item associated with the specified position in the data set.
-     * 获取与数据集中指定位置的数据项。如果未找到数据，则返回 null
+     * 获取与数据集中指定位置的数据项。
      *
      * @param position Position of the item whose data we want within the adapter's
      * data set.
      * @return The data at the specified position.
      */
-    fun getItem(@IntRange(from = 0) position: Int): T? = items.getOrNull(position)
+    open fun getItem(@IntRange(from = 0) position: Int): T = items[position]
 
     /**
      * 获取对应首个匹配的 item 数据的索引。如果返回 -1，表示不存在

--- a/library/src/main/java/com/chad/library/adapter/base/BaseSingleItemAdapter.kt
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseSingleItemAdapter.kt
@@ -10,25 +10,29 @@ import androidx.recyclerview.widget.RecyclerView
  * @param VH viewHolder类型 type of the viewHolder
  * @property mItem 数据 data
  */
-abstract class BaseSingleItemAdapter<T, VH : RecyclerView.ViewHolder>(private var mItem: T? = null) :
-    BaseQuickAdapter<Any?, VH>() {
+abstract class BaseSingleItemAdapter<T, VH : RecyclerView.ViewHolder>(private var mItem:T) :
+    BaseQuickAdapter<T, VH>() {
 
-    protected abstract fun onBindViewHolder(holder: VH, item: T?)
+    protected abstract fun onBindViewHolder(holder: VH, item: T)
 
-    open fun onBindViewHolder(holder: VH, item: T?, payloads: List<Any>) {
+    open fun onBindViewHolder(holder: VH, item: T, payloads: List<Any>) {
         onBindViewHolder(holder, item)
     }
 
-    final override fun onBindViewHolder(holder: VH, position: Int, item: Any?) {
+    final override fun onBindViewHolder(holder: VH, position: Int, item: T) {
         onBindViewHolder(holder, mItem)
     }
 
-    final override fun onBindViewHolder(holder: VH, position: Int, item: Any?, payloads: List<Any>) {
+    final override fun onBindViewHolder(holder: VH, position: Int, item: T, payloads: List<Any>) {
         onBindViewHolder(holder, mItem, payloads)
     }
 
-    final override fun getItemCount(items: List<Any?>): Int {
+    final override fun getItemCount(items: List<T>): Int {
         return 1
+    }
+
+    override fun getItem(position: Int): T {
+        return mItem
     }
 
     /**
@@ -37,7 +41,7 @@ abstract class BaseSingleItemAdapter<T, VH : RecyclerView.ViewHolder>(private va
      * @param t
      * @param payload
      */
-    fun setItem(t: T?, payload: Any?) {
+    fun setItem(t: T, payload: Any?) {
         mItem = t
         notifyItemChanged(0, payload)
     }
@@ -45,34 +49,34 @@ abstract class BaseSingleItemAdapter<T, VH : RecyclerView.ViewHolder>(private va
     /**
      * 获取/设置 item 数据
      */
-    var item: T?
+    var item: T
         get() = mItem
         set(value) {
             mItem = value
             notifyItemChanged(0)
         }
 
-    override fun submitList(list: List<Any?>?) {
+    override fun submitList(list: List<T>?) {
         throw RuntimeException("Please use setItem()")
     }
 
-    override fun add(data: Any?) {
+    override fun add(data: T) {
         throw RuntimeException("Please use setItem()")
     }
 
-    override fun add(position: Int, data: Any?) {
+    override fun add(position: Int, data: T) {
         throw RuntimeException("Please use setItem()")
     }
 
-    override fun addAll(collection: Collection<Any?>) {
+    override fun addAll(collection: Collection<T>) {
         throw RuntimeException("Please use setItem()")
     }
 
-    override fun addAll(position: Int, collection: Collection<Any?>) {
+    override fun addAll(position: Int, collection: Collection<T>) {
         throw RuntimeException("Please use setItem()")
     }
 
-    override fun remove(data: Any?) {
+    override fun remove(data: T) {
         throw RuntimeException("Please use setItem()")
     }
 
@@ -80,7 +84,7 @@ abstract class BaseSingleItemAdapter<T, VH : RecyclerView.ViewHolder>(private va
         throw RuntimeException("Please use setItem()")
     }
 
-    override fun set(position: Int, data: Any?) {
+    override fun set(position: Int, data: T) {
         throw RuntimeException("Please use setItem()")
     }
 }

--- a/library/src/main/java/com/chad/library/adapter/base/BaseSingleItemAdapter.kt
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseSingleItemAdapter.kt
@@ -2,6 +2,23 @@ package com.chad.library.adapter.base
 
 import androidx.recyclerview.widget.RecyclerView
 
+abstract class SimpleSingleItemAdapter<VH : RecyclerView.ViewHolder>() :
+    BaseSingleItemAdapter<Any?, VH>(null) {
+
+    protected abstract fun onBindViewHolder(holder: VH)
+    final override fun onBindViewHolder(holder: VH, item: Any?) {
+        onBindViewHolder(holder)
+    }
+
+    open fun onBindViewHolder(holder: VH, payloads: List<Any>) {
+        onBindViewHolder(holder)
+    }
+
+    final override fun onBindViewHolder(holder: VH, item: Any?, payloads: List<Any>) {
+        onBindViewHolder(holder, payloads)
+    }
+}
+
 /**
  * Adapter for single item
  * 只有单个/一个 item 情况下的 Adapter
@@ -10,7 +27,7 @@ import androidx.recyclerview.widget.RecyclerView
  * @param VH viewHolder类型 type of the viewHolder
  * @property mItem 数据 data
  */
-abstract class BaseSingleItemAdapter<T, VH : RecyclerView.ViewHolder>(private var mItem:T) :
+abstract class BaseSingleItemAdapter<T, VH : RecyclerView.ViewHolder>(private var mItem: T) :
     BaseQuickAdapter<T, VH>() {
 
     protected abstract fun onBindViewHolder(holder: VH, item: T)

--- a/library/src/main/java/com/chad/library/adapter/base/BaseSingleItemAdapter.kt
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseSingleItemAdapter.kt
@@ -5,7 +5,7 @@ import androidx.recyclerview.widget.RecyclerView
 abstract class SimpleSingleItemAdapter<VH : RecyclerView.ViewHolder>() :
     BaseSingleItemAdapter<Any?, VH>(null) {
 
-    protected abstract fun onBindViewHolder(holder: VH)
+    protected open fun onBindViewHolder(holder: VH) {}
     final override fun onBindViewHolder(holder: VH, item: Any?) {
         onBindViewHolder(holder)
     }


### PR DESCRIPTION
避免为了SingleItemAdapter特例做出过多影响使用体验的让步

- 允许重载 getItem;
- 仅在明确需要的场景下允许item为空, fix #3793; 
- 提供默认item为空的 SimpleSingleItemAdapter

    -为SimpleSingleItemAdapter 提供默认为空的 onBindViewHolde
