### PR TITLE
chore(library): 移除多余的 Data Binding 混淆规则

### DIFF
--- a/library/proguard-rules.pro
+++ b/library/proguard-rules.pro
@@ -15,8 +15,3 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
-
-# Data binding混淆规则
--keep class * {
- @androidx.databinding.BindingAdapter <methods>;
-}


### PR DESCRIPTION
  - 移除 v4.3.2 升 v4.3.3 期间新增的混淆规则, 因为此规则会导致宿主项目的部分类无法正常被R8所混淆

  - 复现仓库 [BRVAH-BUG](https://github.com/HdShare/BRVAH-BUG)
  
<img width="656" height="497" alt="image" src="https://github.com/user-attachments/assets/16fcf2b7-7cba-4fb4-9b92-0f22c6ad0cc6" />
